### PR TITLE
Support user agent exceptions

### DIFF
--- a/lib/mobylette/respond_to_mobile_requests.rb
+++ b/lib/mobylette/respond_to_mobile_requests.rb
@@ -41,6 +41,7 @@ module Mobylette
       @@mobylette_options[:fallback_chains]    = { mobile: [:mobile, :html] }
       @@mobylette_options[:mobile_user_agents] = Mobylette::MobileUserAgents.new
       @@mobylette_options[:devices]            = Hash.new
+      @@mobylette_options[:skip_user_agents]   = []
 
       cattr_accessor :mobylette_resolver
       self.mobylette_resolver = Mobylette::Resolvers::ChainedFallbackResolver.new()
@@ -75,6 +76,8 @@ module Mobylette
       #     Once a device is registered you may call the helper request_device?(device_symb)
       #     to see if the request comes from that device or not.
       #     By default :iphone, :ipad, :ios and :android are already registered.
+      # * skip_user_agents: [:ipad, :android]
+      #     Don't consider these user agents mobile devices.
       #
       # Example Usage:
       #
@@ -153,7 +156,15 @@ module Mobylette
     #
     def respond_as_mobile?
       impediments = stop_processing_because_xhr? || stop_processing_because_param?
-      (not impediments) && (force_mobile_by_session? || is_mobile_request? || params[:format] == 'mobile')
+      (not impediments) && (force_mobile_by_session? || allow_mobile_response? || params[:format] == 'mobile')
+    end
+
+    def allow_mobile_response?
+      user_agent_included? && is_mobile_request?
+    end
+
+    def user_agent_included?
+      request.user_agent.to_s.downcase !~ Regexp.union(self.mobylette_options[:skip_user_agents].map(&:to_s))
     end
 
     # Private: Returns true if the visitor has the force_mobile set in it's session

--- a/spec/lib/respond_to_mobile_requests_spec.rb
+++ b/spec/lib/respond_to_mobile_requests_spec.rb
@@ -164,6 +164,8 @@ module Mobylette
           subject.stub(:force_mobile_by_session?).and_return(false)
           subject.stub(:is_mobile_request?).and_return(false)
           subject.stub(:params).and_return({})
+          request = double("request", user_agent: "android")
+          subject.stub(:request).and_return(request)
         end
 
         it "should be true if force_mobile_by_session? is true" do
@@ -180,6 +182,34 @@ module Mobylette
           subject.stub(:params).and_return({format: 'mobile'})
           subject.send(:respond_as_mobile?).should be_true
         end
+      end
+
+      context "with skip_user_agents config option set" do
+        before(:each) do
+          subject.stub(:stop_processing_because_xhr?).and_return(false)
+          subject.stub(:stop_processing_because_param?).and_return(false)
+          subject.stub(:force_mobile_by_session?).and_return(false)
+          subject.stub(:is_mobile_request?).and_return(true)
+          subject.stub(:params).and_return({})
+          request = double("request", user_agent: "ipad")
+          subject.stub(:request).and_return(request)
+        end
+
+        it "should be false if skip_user_agents contains the current user agent" do
+          subject.mobylette_options[:skip_user_agents] = [:ipad, :android]
+          subject.send(:respond_as_mobile?).should be_false
+        end
+
+        it "should be true if skip_user_agents is not set" do
+          subject.mobylette_options[:skip_user_agents] = []
+          subject.send(:respond_as_mobile?).should be_true
+        end
+
+        it "should be true if skip_user_agents does not contain the current user agent" do
+          subject.mobylette_options[:skip_user_agents] = [:android]
+          subject.send(:respond_as_mobile?).should be_true
+        end
+
       end
     end
 


### PR DESCRIPTION
Specify user agents that should not be considered mobile via the mobylette_config method.

The use case that drove this: we want to serve our normal site to the ipad, but our mobile site to every other mobile device. We could use the mobile_user_agents config option to pass a new list that does not include the ipad, but then we've duplicated the DEFAULT_USER_AGENTS list. It's easier to provide a way to specify an exception. 
