### PR TITLE
Added Android Phone as a default device

### DIFF
--- a/lib/mobylette/devices.rb
+++ b/lib/mobylette/devices.rb
@@ -9,6 +9,7 @@ module Mobylette
         android2: %r{android\s+2\.}i,
         android3: %r{android\s+3\.}i,
         android4: %r{android\s+4\.}i,
+        android_phone: %r{android.*mobile}i,
         iphone:   %r{iphone}i,
         ipad:     %r{ipad}i,
         ios:      %r{iphone|ipad}i,

--- a/spec/lib/respond_to_mobile_requests_spec.rb
+++ b/spec/lib/respond_to_mobile_requests_spec.rb
@@ -252,6 +252,11 @@ module Mobylette
         subject.send(:request_device?, :iphone).should be_false
         subject.send(:request_device?, :custom_phone).should be_true
       end
+      it "should match an android phone" do
+        subject.stub_chain(:request, :user_agent).and_return('This is Android browser Mobile')
+        subject.send(:request_device?, :iphone).should be_false
+        subject.send(:request_device?, :android_phone).should be_true
+      end
     end
 
     describe "#set_mobile_format" do


### PR DESCRIPTION
Hi! I've used this modification in a personal project and maybe you would like to introduce it into the gem.

I think that it is useful to include the android phone as a default device because of the same reason that we have iphone and ipad as two different devices. I would have included android_tablet too, but I can't find the way to do the detection with a simple regexp and also didn't want to do a complicated stuff into the code.

Thanks for your time :)
