### PR TITLE
Bump json dependancy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     hike (1.2.1)
     i18n (0.6.0)
     journey (1.0.3)
-    json (1.6.6)
+    json (1.7.7)
     mail (2.4.4)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)


### PR DESCRIPTION
In some environment, json v1.6.6 with ruby2.0 crashes bundle install.
https://github.com/flori/json/issues/163
https://github.com/mitchellh/vagrant/pull/1392

This is problem in each environment (actually, pass in travis-ci), but update json solve this.

In my bundle process below:

```
Installing json (1.6.6)
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

    /Users/sane/.rbenv/versions/2.0.0-p0/bin/ruby extconf.rb 
creating Makefile

make
compiling generator.c
generator.c:867:22: warning: '&&' within '||' [-Wlogical-op-parentheses]
    return *p == '[' && *q == ']' || *p == '{' && *q == '}';
           ~~~~~~~~~~^~~~~~~~~~~~ ~~
generator.c:867:22: note: place parentheses around the '&&' expression to silence this warning
    return *p == '[' && *q == ']' || *p == '{' && *q == '}';
                     ^
           (                     )
generator.c:867:48: warning: '&&' within '||' [-Wlogical-op-parentheses]
    return *p == '[' && *q == ']' || *p == '{' && *q == '}';
                                  ~~ ~~~~~~~~~~^~~~~~~~~~~~
generator.c:867:48: note: place parentheses around the '&&' expression to silence this warning
    return *p == '[' && *q == ']' || *p == '{' && *q == '}';
                                               ^
                                     (                     )
2 warnings generated.
linking shared-object json/ext/generator.bundle

make install
/usr/bin/install -c -m 0755 generator.bundle /Users/sane/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/json-1.6.6/ext/json/ext/json/ext
install: /Users/sane/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/json-1.6.6/ext/json/ext/json/ext: No such file or directory
make: *** [install-so] Error 71


Gem files will remain installed in /Users/sane/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/json-1.6.6 for inspection.
Results logged to /Users/sane/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/json-1.6.6/ext/json/ext/generator/gem_make.out

An error occurred while installing json (1.6.6), and Bundler cannot continue.
Make sure that `gem install json -v '1.6.6'` succeeds before bundling.
```
