### PR TITLE
return boolean for is_mobile_request?

### DIFF
--- a/lib/mobylette/respond_to_mobile_requests.rb
+++ b/lib/mobylette/respond_to_mobile_requests.rb
@@ -132,7 +132,7 @@ module Mobylette
     # Private: Tells if the request comes from a mobile user_agent or not
     #
     def is_mobile_request?
-      !((not user_agent_excluded?) && request.user_agent.to_s.downcase =~ @@mobylette_options[:mobile_user_agents].call).nil?
+      (not user_agent_excluded?) && !(request.user_agent.to_s.downcase =~ @@mobylette_options[:mobile_user_agents].call).nil?
     end
 
     # Private: Returns if this request comes from the informed device


### PR DESCRIPTION
I'm using Rails 4 with Ruby 2.0.0, and the helper method `is_mobile_request?` is returning the result of `request.user_agent.to_s.downcase =~ @@mobylette_options[:mobile_user_agents].call`. When the user agent doesn't match, the method returns `nil`. When the user agent is mobile, it returns the match in `:mobile_user_agents` (for iphone, this is 13).

Because of this, mobylette was not correctly rendering mobile templates. After this change, everything is working well.
