### PR TITLE
replaced @@mobylette_options by self.mobylette_options.

### DIFF
--- a/lib/mobylette/respond_to_mobile_requests.rb
+++ b/lib/mobylette/respond_to_mobile_requests.rb
@@ -36,16 +36,17 @@ module Mobylette
       before_filter :handle_mobile
 
       cattr_accessor :mobylette_options
-      @@mobylette_options = Hash.new
-      @@mobylette_options[:skip_xhr_requests]  = true
-      @@mobylette_options[:fallback_chains]    = { mobile: [:mobile, :html] }
-      @@mobylette_options[:mobile_user_agents] = Mobylette::MobileUserAgents.new
-      @@mobylette_options[:devices]            = Hash.new
-      @@mobylette_options[:skip_user_agents]   = []
+
+      self.mobylette_options = Hash.new
+      self.mobylette_options[:skip_xhr_requests]  = true
+      self.mobylette_options[:fallback_chains]    = { mobile: [:mobile, :html] }
+      self.mobylette_options[:mobile_user_agents] = Mobylette::MobileUserAgents.new
+      self.mobylette_options[:devices]            = Hash.new
+      self.mobylette_options[:skip_user_agents]   = []
 
       cattr_accessor :mobylette_resolver
       self.mobylette_resolver = Mobylette::Resolvers::ChainedFallbackResolver.new({}, self.view_paths)
-      self.mobylette_resolver.replace_fallback_formats_chain(@@mobylette_options[:fallback_chains])
+      self.mobylette_resolver.replace_fallback_formats_chain(self.mobylette_options[:fallback_chains])
       append_view_path self.mobylette_resolver
     end
 
@@ -132,7 +133,7 @@ module Mobylette
     # Private: Tells if the request comes from a mobile user_agent or not
     #
     def is_mobile_request?
-      (not user_agent_excluded?) && !(request.user_agent.to_s.downcase =~ @@mobylette_options[:mobile_user_agents].call).nil?
+      (not user_agent_excluded?) && !(request.user_agent.to_s.downcase =~ self.mobylette_options[:mobile_user_agents].call).nil?
     end
 
     # Private: Returns if this request comes from the informed device


### PR DESCRIPTION
It fixes NoMethodError undefined method `[]' for nil:NilClass

I've always had this problem in JRuby. I used to solve it adding in my controller:

self.mobylette_options ||= {}

after 

include Mobylette::RespondToMobileRequests

and adding again a configuration

mobylette_config do |config|
    config[:mobile_user_agents] = proc { %r{iphone|android}i }
    config[:fallback_chains] = { mobile: [:mobile, :html] }
    config[:skip_user_agents] = []
end
