### PR TITLE
Downcase options :skip_user_agents

### DIFF
--- a/lib/mobylette/respond_to_mobile_requests.rb
+++ b/lib/mobylette/respond_to_mobile_requests.rb
@@ -160,7 +160,7 @@ module Mobylette
     # Private: Rertuns true if the current user agent should be skipped by configuration
     #
     def user_agent_excluded?
-      request.user_agent.to_s.downcase =~ Regexp.union([self.mobylette_options[:skip_user_agents]].flatten.map(&:to_s))
+      request.user_agent.to_s.downcase =~ Regexp.union([self.mobylette_options[:skip_user_agents]].flatten.map(&:to_s).map(&:downcase))
     end
 
     # Private: Returns true if the visitor has the force_mobile set in it's session


### PR DESCRIPTION
The request.user_agent is downcased and so should the skip_user_agents from the options.
