### PR TITLE
Handle change in Rails 4.2.5.1 private method

### DIFF
--- a/lib/mobylette/resolvers/chained_fallback_resolver.rb
+++ b/lib/mobylette/resolvers/chained_fallback_resolver.rb
@@ -24,9 +24,9 @@ module Mobylette
       #     ...
       #   }
       #
-      # It will add the fallback chain array of the 
+      # It will add the fallback chain array of the
       # request.format to the resolver.
-      # 
+      #
       # If the format.request is not defined in formats,
       # it will behave as a normal FileSystemResovler.
       #
@@ -39,13 +39,13 @@ module Mobylette
       # Private: finds the right template on the filesystem,
       #         using fallback if needed
       #
-      def find_templates(name, prefix, partial, details)
+      def find_templates(name, prefix, partial, details, outside_app_allowed = false)
         # checks if the format has a fallback chain
         if @fallback_formats.has_key?(details[:formats].first)
           details = details.dup
-          details[:formats] = Array.wrap(@fallback_formats[details[:formats].first]) 
+          details[:formats] = Array.wrap(@fallback_formats[details[:formats].first])
         end
-        super(name, prefix, partial, details)
+        super(name, prefix, partial, details, outside_app_allowed)
       end
 
       # Helper for building query glob string based on resolver's pattern.


### PR DESCRIPTION
Starting in (https://github.com/rails/rails/commit/0c5c32aa7cea5ee1ea60bd1f87dfa5c7e7146a54)[Rails 4.2.5.1], the find_templates now takes a fifth argument. This causes a problem when the `chained_fallback_resolver` is called to find the template. 

This pull requests adds an optional fifth argument to match the internal Rails method.