### PR TITLE
Adjust the arguments of find_templates() for Rails 4.2.5.2, 4.1.14.2 …and 3.2.22.2

### DIFF
--- a/lib/mobylette/resolvers/chained_fallback_resolver.rb
+++ b/lib/mobylette/resolvers/chained_fallback_resolver.rb
@@ -39,13 +39,13 @@ module Mobylette
       # Private: finds the right template on the filesystem,
       #         using fallback if needed
       #
-      def find_templates(name, prefix, partial, details)
+      def find_templates(name, prefix, partial, details, outside_app_allowed = false)
         # checks if the format has a fallback chain
         if @fallback_formats.has_key?(details[:formats].first)
           details = details.dup
           details[:formats] = Array.wrap(@fallback_formats[details[:formats].first]) 
         end
-        super(name, prefix, partial, details)
+        super(name, prefix, partial, details, outside_app_allowed)
       end
 
       # Helper for building query glob string based on resolver's pattern.


### PR DESCRIPTION
Rails 4.2.5.2, 4.1.14.2 and 3.2.22.2 have been released and these include a break change for find_templates().
Rendering templates causes an error such as `ArgumentError: wrong number of arguments (5 for 4)` 
This patch adjusts the arguments of find_templates().

refs: http://weblog.rubyonrails.org/2016/2/29/Rails-4-2-5-2-4-1-14-2-3-2-22-2-have-been-released/

see also:
https://github.com/rails/rails/compare/v4.2.5.1...v4.2.5.2
https://github.com/rails/rails/compare/v4.1.14.1...v4.1.14.2
https://github.com/rails/rails/compare/v3.2.22.1...v3.2.22.2