### PR TITLE
Update bundler before travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ rvm:
   - 2.0.0
   #- ruby-head
 script: "bundle exec rspec spec"
+before_install:
+  - gem update bundler


### PR DESCRIPTION
Latest builds on travis are broken because bundler is too old and contains some issues.
Refs: bundler/bundler#3558 travis-ci/travis-ci#3531