### PR TITLE
fixed mobylette load error in Rails5.0.0.rc1

### DIFF
--- a/lib/mobylette/resolvers/chained_fallback_resolver.rb
+++ b/lib/mobylette/resolvers/chained_fallback_resolver.rb
@@ -1,3 +1,4 @@
+require 'action_view/template/resolver'
 module Mobylette
   module Resolvers
     class ChainedFallbackResolver < ::ActionView::FileSystemResolver
@@ -24,9 +25,9 @@ module Mobylette
       #     ...
       #   }
       #
-      # It will add the fallback chain array of the 
+      # It will add the fallback chain array of the
       # request.format to the resolver.
-      # 
+      #
       # If the format.request is not defined in formats,
       # it will behave as a normal FileSystemResovler.
       #
@@ -43,7 +44,7 @@ module Mobylette
         # checks if the format has a fallback chain
         if @fallback_formats.has_key?(details[:formats].first)
           details = details.dup
-          details[:formats] = Array.wrap(@fallback_formats[details[:formats].first]) 
+          details[:formats] = Array.wrap(@fallback_formats[details[:formats].first])
         end
         super(name, prefix, partial, details)
       end

--- a/lib/mobylette/respond_to_mobile_requests.rb
+++ b/lib/mobylette/respond_to_mobile_requests.rb
@@ -33,7 +33,7 @@ module Mobylette
       helper_method :is_mobile_view?
       helper_method :request_device?
 
-      before_filter :handle_mobile
+      before_action :handle_mobile
 
       cattr_accessor :mobylette_options
       @@mobylette_options = Hash.new
@@ -101,7 +101,7 @@ module Mobylette
 
       # Private: Configures how the resolver shall handle fallbacks.
       #
-      # if options has a :fallback_chains key, it will use it 
+      # if options has a :fallback_chains key, it will use it
       # as the fallback rules for the resolver, the format should
       # be a hash, where each key defines a array of formats.
       # Example:
@@ -213,7 +213,7 @@ module Mobylette
           return device if request_device?(device)
         end
       end
-      :mobile 
+      :mobile
     end
 
   end


### PR DESCRIPTION
The error message is:  

```
`rescue in block (2 levels) in require': There was an error while trying to load the gem 'mobylette'. (Bundler::GemRequireError)
Gem Load Error is: uninitialized constant ActionView::FileSystemResolver
```

need to require specify rails module:`require 'action_view/template/resolver'`  

16-5-17 update:  

> before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead
