### PR TITLE
Hotfix/fix before filter deprecation

### DIFF
--- a/lib/mobylette/resolvers/chained_fallback_resolver.rb
+++ b/lib/mobylette/resolvers/chained_fallback_resolver.rb
@@ -24,9 +24,9 @@ module Mobylette
       #     ...
       #   }
       #
-      # It will add the fallback chain array of the 
+      # It will add the fallback chain array of the
       # request.format to the resolver.
-      # 
+      #
       # If the format.request is not defined in formats,
       # it will behave as a normal FileSystemResovler.
       #
@@ -39,11 +39,11 @@ module Mobylette
       # Private: finds the right template on the filesystem,
       #         using fallback if needed
       #
-      def find_templates(name, prefix, partial, details)
+      def find_templates(name, prefix, partial, details, outside_app_allowed = false)
         # checks if the format has a fallback chain
         if @fallback_formats.has_key?(details[:formats].first)
           details = details.dup
-          details[:formats] = Array.wrap(@fallback_formats[details[:formats].first]) 
+          details[:formats] = Array.wrap(@fallback_formats[details[:formats].first])
         end
         super(name, prefix, partial, details)
       end

--- a/lib/mobylette/respond_to_mobile_requests.rb
+++ b/lib/mobylette/respond_to_mobile_requests.rb
@@ -33,7 +33,7 @@ module Mobylette
       helper_method :is_mobile_view?
       helper_method :request_device?
 
-      before_filter :handle_mobile
+      before_action :handle_mobile
 
       cattr_accessor :mobylette_options
       @@mobylette_options = Hash.new
@@ -101,7 +101,7 @@ module Mobylette
 
       # Private: Configures how the resolver shall handle fallbacks.
       #
-      # if options has a :fallback_chains key, it will use it 
+      # if options has a :fallback_chains key, it will use it
       # as the fallback rules for the resolver, the format should
       # be a hash, where each key defines a array of formats.
       # Example:
@@ -213,7 +213,7 @@ module Mobylette
           return device if request_device?(device)
         end
       end
-      :mobile 
+      :mobile
     end
 
   end


### PR DESCRIPTION
Fixes the following deprecation warning in Rails 5:
```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from block in <module:RespondToMobileRequests> at /Users/nathan/.asdf/installs/ruby/2.4.6/lib/ruby/gems/2.4.0/bundler/gems/mobylette-ab20bd5fcef4/lib/mobylette/respond_to_mobile_requests.rb:36)
```